### PR TITLE
feat: enable drag interaction on Bloch sphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ npm run dev
 ```
 
 - Press **H** to create |+⟩ (⟨X⟩≈1).  
-- Increase **Dephasing p** to watch the arrow **shrink** and Purity → 0.5.  
+- Increase **Dephasing p** to watch the arrow **shrink** and Purity → 0.5.
 - Rotate the sphere with your mouse if you don’t notice directional changes.
+- Drag the arrow on the sphere to set a custom state.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ const demoDephase = () => {
     <div>
       <h1 style={{ margin: "8px 0 6px" }}>Qubit Lab — Bloch Playground</h1>
       <p style={{ marginTop: 0, color: "#666" }}>H/X/Y/Z gates + Dephasing noise. Arrow length encodes mixedness (|r|). Note: You start in |0⟩ (on +Z). Dephasing has no visible effect on |0⟩ — first create a superposition (e.g., click H for |+⟩).</p>
-      <BlochSphereGL x={state.x} y={state.y} z={state.z} />
+      <BlochSphereGL x={state.x} y={state.y} z={state.z} onVectorChange={(nx,ny,nz)=>update({ x:nx, y:ny, z:nz, purity:1 })} />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8, marginTop: 8 }}>
         <div>⟨X⟩ = <b>{state.x.toFixed(3)}</b></div>
         <div>⟨Y⟩ = <b>{state.y.toFixed(3)}</b></div>


### PR DESCRIPTION
## Summary
- allow users to drag the Bloch vector directly on the sphere
- plumb dragged coordinates back into app state
- document new drag interaction

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*
- `apt-get install -y nodejs npm` *(fails: package not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be71bad6c483309eb3508cd9638c6a