### PR TITLE
Synchronize dragged Bloch vector with worker and stabilize worker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 Visual Bloch sphere with H/X/Y/Z gates and **dephasing noise**.
 **New in v2:** Arrow length now encodes |r| (mixedness), OrbitControls for rotation, and ⟨X,Y,Z⟩ readouts.
+Dragging the arrow now synchronizes the underlying state so subsequent gates operate on the rotated qubit.
 
 ## Quickstart
 ```bash
@@ -14,4 +15,4 @@ npm run dev
 - Press **H** to create |+⟩ (⟨X⟩≈1).  
 - Increase **Dephasing p** to watch the arrow **shrink** and Purity → 0.5.
 - Rotate the sphere with your mouse if you don’t notice directional changes.
-- Drag the arrow on the sphere to set a custom state.
+- Drag the arrow on the sphere to set a custom state (simulation stays in sync).

--- a/src/engine/engine.worker.ts
+++ b/src/engine/engine.worker.ts
@@ -1,6 +1,6 @@
 
 /// <reference lib="webworker" />
-import { M2, H, X, Y, Z, applyUnitary, applyDephase, blochAndPurity, ket0bra0 } from "./math";
+import { M2, H, X, Y, Z, applyUnitary, applyDephase, blochAndPurity, ket0bra0, rhoFromBloch } from "./math";
 
 let rho: M2 = ket0bra0();
 
@@ -8,6 +8,7 @@ type Msg =
   | { type: "reset" }
   | { type: "gate", gate: "H" | "X" | "Y" | "Z" }
   | { type: "dephase", p: number }
+  | { type: "setBloch", x: number, y: number, z: number }
   | { type: "snapshot" };
 
 const post = () => (self as any).postMessage({
@@ -29,6 +30,9 @@ self.addEventListener("message", (ev: MessageEvent<Msg>) => {
     }
     case "dephase":
       rho = applyDephase(rho, m.p);
+      break;
+    case "setBloch":
+      rho = rhoFromBloch(m.x, m.y, m.z);
       break;
     case "snapshot":
       break;

--- a/src/engine/math.ts
+++ b/src/engine/math.ts
@@ -16,6 +16,12 @@ export const H: M2 = [[c(1/Math.SQRT2),c(1/Math.SQRT2)],[c(1/Math.SQRT2),c(-1/Ma
 
 export const ket0bra0 = (): M2 => [[c(1),c(0)],[c(0),c(0)]];
 
+// Density matrix from Bloch vector (assumes |r|≤1)
+export const rhoFromBloch = (x:number, y:number, z:number): M2 => [
+  [c(0.5*(1+z), 0), c(0.5*x, -0.5*y)],
+  [c(0.5*x, 0.5*y), c(0.5*(1-z), 0)]
+];
+
 // multiply 2x2 matrices: a*b
 const m2mul = (a:M2,b:M2): M2 => {
   const r: M2 = [[c(),c()],[c(),c()]];


### PR DESCRIPTION
## Summary
- Update math helpers and worker to accept Bloch vector messages for setting `rho`
- Create the engine worker once via `useRef` to avoid double instantiation in React Strict Mode
- Sync UI drag events to the worker so simulation stays consistent and update README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68be8c5ec95c8330a65230b6582bef10